### PR TITLE
active daos endpoints

### DIFF
--- a/apps/api/src/common/metric.service.ts
+++ b/apps/api/src/common/metric.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   ContractContext,
   DaoContractContext,
+  DaoStatsFunc,
   DaoStatsHistoryService,
   DaoStatsMetric,
   DaoStatsService,
@@ -25,7 +26,7 @@ export class MetricService {
   async total(
     context: DaoContractContext | ContractContext,
     metric: DaoStatsMetric | DaoStatsMetric[],
-    daoAverage?: boolean,
+    func: DaoStatsFunc = 'sum',
   ): Promise<TotalMetric> {
     const { contractId, dao } = context as DaoContractContext;
 
@@ -36,13 +37,13 @@ export class MetricService {
         contractId,
         dao,
         metric,
-        daoAverage,
+        func,
       }),
       this.daoStatsHistoryService.getLastValue({
         contractId,
         dao,
         metric,
-        daoAverage,
+        func,
         to: dayAgo.valueOf(),
       }),
     ]);
@@ -57,7 +58,7 @@ export class MetricService {
     context: ContractContext | DaoContractContext,
     metricQuery: MetricQuery,
     metric: DaoStatsMetric | DaoStatsMetric[],
-    daoAverage?: boolean,
+    func?: DaoStatsFunc,
   ): Promise<MetricResponse> {
     const { contractId, dao } = context as DaoContractContext;
     const { from, to } = metricQuery;
@@ -66,7 +67,7 @@ export class MetricService {
       contractId,
       dao,
       metric,
-      daoAverage,
+      func,
       from,
       to,
     });

--- a/apps/api/src/general/dto/general-total.dto.ts
+++ b/apps/api/src/general/dto/general-total.dto.ts
@@ -9,6 +9,9 @@ export class GeneralTotalResponse {
   activity: TotalMetric;
 
   @ApiProperty()
+  activeDaos: TotalMetric;
+
+  @ApiProperty()
   groups: TotalMetric;
 
   @ApiProperty()

--- a/apps/api/src/general/general.controller.ts
+++ b/apps/api/src/general/general.controller.ts
@@ -90,6 +90,21 @@ export class GeneralController {
   @ApiBadRequestResponse({
     description: 'Bad Request Response based on the query params set',
   })
+  @Get('/active-daos')
+  async activeDaos(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Query(MetricQueryPipe) metricQuery: MetricQuery,
+  ): Promise<MetricResponse> {
+    return this.generalService.activeDaos(context, metricQuery);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: MetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
   @Get('/groups')
   async groups(
     @Param(ContractContextPipe) context: ContractContext,

--- a/apps/api/src/general/general.service.ts
+++ b/apps/api/src/general/general.service.ts
@@ -31,11 +31,16 @@ export class GeneralService {
     const monthAgo = moment().subtract(1, 'month');
     const twoMonthsAgo = moment().subtract(2, 'months');
 
-    const [dao, groups, averageGroups, activity, monthAgoActivity] =
+    const [dao, activeDaos, groups, averageGroups, activity, monthAgoActivity] =
       await Promise.all([
         this.metricService.total(context, DaoStatsMetric.DaoCount),
+        this.metricService.total(
+          context,
+          DaoStatsMetric.ProposalsInProgressCount,
+          'count',
+        ),
         this.metricService.total(context, DaoStatsMetric.GroupsCount),
-        this.metricService.total(context, DaoStatsMetric.GroupsCount, true),
+        this.metricService.total(context, DaoStatsMetric.GroupsCount, 'avg'),
         this.transactionService.getContractActivityCount(context, {
           from: monthAgo.valueOf(),
         }),
@@ -51,6 +56,7 @@ export class GeneralService {
         count: activity.count,
         growth: getGrowth(activity.count, monthAgoActivity.count),
       },
+      activeDaos,
       groups,
       averageGroups,
     };
@@ -152,6 +158,18 @@ export class GeneralService {
     return { metrics, total };
   }
 
+  async activeDaos(
+    context: ContractContext | DaoContractContext,
+    metricQuery: MetricQuery,
+  ): Promise<MetricResponse> {
+    return this.metricService.history(
+      context,
+      metricQuery,
+      DaoStatsMetric.ProposalsInProgressCount,
+      'count',
+    );
+  }
+
   async groups(
     context: ContractContext | DaoContractContext,
     metricQuery: MetricQuery,
@@ -182,7 +200,7 @@ export class GeneralService {
       context,
       metricQuery,
       DaoStatsMetric.GroupsCount,
-      true,
+      'avg',
     );
   }
 }

--- a/libs/common/src/dao-stats-history.service.ts
+++ b/libs/common/src/dao-stats-history.service.ts
@@ -2,7 +2,7 @@ import { Connection, InsertResult, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectConnection, InjectRepository } from '@nestjs/typeorm';
 
-import { DaoStatsDto, DaoStatsHistory, DaoStatsMetric } from '.';
+import { DaoStatsDto, DaoStatsFunc, DaoStatsHistory, DaoStatsMetric } from '.';
 
 export interface DaoStatsHistoryValueParams {
   from?: number;
@@ -10,7 +10,7 @@ export interface DaoStatsHistoryValueParams {
   contractId: string;
   dao?: string;
   metric: DaoStatsMetric | DaoStatsMetric[];
-  daoAverage?: boolean;
+  func?: DaoStatsFunc;
 }
 
 export type DaoStatsHistoryHistoryParams = DaoStatsHistoryValueParams;
@@ -58,7 +58,7 @@ export class DaoStatsHistoryService {
     contractId,
     dao,
     metric,
-    daoAverage,
+    func = 'sum',
     from,
     to,
   }: DaoStatsHistoryValueParams): Promise<number> {
@@ -99,11 +99,11 @@ export class DaoStatsHistoryService {
     const [result] = await this.connection.query(
       `
           with data as (${subQuery})
-          select ${daoAverage ? 'avg' : 'sum'}(value) as value
+          select ${func}(value) as value
           from data
           group by date
           order by date desc
-          limit 1
+              limit 1
       `,
       params,
     );
@@ -119,7 +119,7 @@ export class DaoStatsHistoryService {
     contractId,
     dao,
     metric,
-    daoAverage,
+    func = 'sum',
     from,
     to,
   }: DaoStatsHistoryHistoryParams): Promise<DaoStatsHistoryHistoryResponse> {
@@ -160,7 +160,7 @@ export class DaoStatsHistoryService {
     const result = await this.connection.query(
       `
           with data as (${subQuery})
-          select date, ${daoAverage ? 'avg' : 'sum'}(value) as value
+          select date, ${func}(value) as value
           from data
           group by date
           order by date

--- a/libs/common/src/dao-stats.service.ts
+++ b/libs/common/src/dao-stats.service.ts
@@ -2,19 +2,20 @@ import { Connection, InsertResult, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectConnection, InjectRepository } from '@nestjs/typeorm';
 
-import { DaoStats, DaoStatsDto, DaoStatsMetric } from '.';
+import { DaoStats, DaoStatsDto, DaoStatsFunc, DaoStatsMetric } from '.';
 
 export interface DaoStatsValueParams {
   contractId: string;
   dao?: string;
   metric: DaoStatsMetric | DaoStatsMetric[];
-  daoAverage?: boolean;
+  func?: DaoStatsFunc;
 }
 
 export interface DaoStatsLeaderboardParams {
   contractId: string;
   dao?: string;
   metric: DaoStatsMetric | DaoStatsMetric[];
+  func?: DaoStatsFunc;
   offset?: number;
   limit?: number;
 }
@@ -55,7 +56,7 @@ export class DaoStatsService {
     contractId,
     dao,
     metric,
-    daoAverage,
+    func,
   }: DaoStatsValueParams): Promise<number> {
     const query = this.repository
       .createQueryBuilder()
@@ -82,7 +83,7 @@ export class DaoStatsService {
     const [result] = await this.connection.query(
       `
           with data as (${subQuery})
-          select ${daoAverage ? 'avg' : 'sum'}(value) as value
+          select ${func}(value) as value
           from data`,
       params,
     );

--- a/libs/common/src/types/dao-stats-func.ts
+++ b/libs/common/src/types/dao-stats-func.ts
@@ -1,0 +1,1 @@
+export type DaoStatsFunc = 'avg' | 'sum' | 'count';

--- a/libs/common/src/types/index.ts
+++ b/libs/common/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './dao-stats-func';
 export * from './dao-stats-metric';
 export * from './dao-stats-metric-group';
 export * from './transaction-type';


### PR DESCRIPTION
Modified endpoint:

`/api/v1/general`

```
{
    ...
    activeDaos: {
         count: number;
         growth: number;
    }
    ...
}
```

Added endpoint:

`/api/v1/general/active-daos`

```
{
  "metrics": [
    {
      "timestamp": number,
      "count": number
    }
  ]
}
```